### PR TITLE
fix disinvestproof bugs 20260423

### DIFF
--- a/src/TTSwap_Market.sol
+++ b/src/TTSwap_Market.sol
@@ -313,7 +313,8 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
         // based on the current market state of the value good.
         goods[_valuegood].investGood(_initial.amount1(), investResult, 100);
 
-        if (investResult.investValue < 100_000_000_000_000) revert TTSwapError(35);
+        if (investResult.investValue < 100_000_000_000_000)
+            revert TTSwapError(35);
 
         // Initialize the new normal good state.
         // amount0: Initial value (pegged to the value good's invested value).
@@ -446,7 +447,8 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
         _checkTrader(_trader);
         _checkGoodActive(_goodid, 10, 12);
         if (_invest.amount0() > 0) {
-            if (goods[_goodid].isInvestBlocked(_invest, _trader)) revert TTSwapError(47);
+            if (goods[_goodid].isInvestBlocked(_invest, _trader))
+                revert TTSwapError(47);
         } else {
             uint128 poolValue = uint128(
                 (uint256(goods[_goodid].investState.amount1()) *
@@ -456,7 +458,6 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
             _invest = toTTSwapUINT256(poolValue, _invest.amount1());
         }
         L_Good.S_GoodInvestReturn memory normalInvest_;
-
 
         if (
             goods[_goodid].currentState.amount1() + _invest.amount1() > 2 ** 109
@@ -486,7 +487,12 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
 
         // Process investment for normal good.
         // Calculates new shares and updates normal good's state.
-        goods[_goodid].investOneTokenGood(_invest.amount1(), _invest.amount0(), normalInvest_, enpower);
+        goods[_goodid].investOneTokenGood(
+            _invest.amount1(),
+            _invest.amount0(),
+            normalInvest_,
+            enpower
+        );
 
         if (normalInvest_.investValue < 1000000) revert TTSwapError(38);
 
@@ -532,7 +538,7 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
      * @param _goodid2 The address of the output good (buying).
      * @param _swapQuantity The swap details:
      *        - amount0: The input quantity of _goodid1.
-     *        - amount1: The minimum output quantity of _goodid2 (slippage protection).
+     *        - amount1: The minimum gross output quantity of _goodid2 before any relayer execution fee.
      * @param _recipient The address to receive the bought goods (if different from trader).
      *                 Also used for referral tracking if different from trader.
      * @param data Additional data for the input token transfer (Permit/Transfer).
@@ -544,12 +550,12 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
      *         - amount1: Actual input quantity swapped.
      * @return good2change The state change of the output good:
      *         - amount0: Fee quantity deducted.
-     *         - amount1: Actual output quantity received.
+     *         - amount1: Gross output quantity from the AMM before any relayer execution fee.
      * @notice This function calculates the swap amount based on the AMM formula, deducts fees,
      * updates reserves, and transfers tokens.
      * @custom:security Protected by reentrancy guard.
      * @custom:security Verifies EIP-712 signature if the caller is a relayer.
-     * @custom:security Checks slippage tolerance (`_swapQuantity.amount1()`).
+     * @custom:security Checks slippage tolerance against gross AMM output (`_swapQuantity.amount1()`).
      * @custom:security Validates that the pool has sufficient liquidity and is not frozen.
      */
     function buyGood(
@@ -622,7 +628,7 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
         if (msg.sender == _trader) {
             _goodid2.safeTransfer(_trader, good2change.amount1());
         } else {
-            // Fee is denominated in output good units to keep payout consistent.
+            // Fee is denominated in output good units and deducted from the delivered payout.
             uint128 feeQuantity = goods[_goodid2]
                 .getGoodState()
                 .getamount1fromamount0(executeFee);
@@ -657,8 +663,8 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
      * @param _goodid2 The address of the output good (paying to).
      * @param _swapQuantity The swap details:
      *        - amount0: The maximum input quantity of _goodid1 (slippage protection).
-     *        - amount1: The exact output quantity of _goodid2 required.
-     * @param _recipient The address to receive the payment (goods).
+     *        - amount1: The target gross output quantity of _goodid2 before any relayer execution fee.
+     * @param _recipient The address to receive the payment (goods). In relayer mode, net delivery may be lower because execution fee is deducted from gross output.
      * @param data Additional data for the input token transfer (Permit/Transfer).
      * @param _trader The address of the trader initiating the payment (must match signer).
      * @param signature The EIP-712 signature authorizing the payment (if msg.sender != _trader).
@@ -668,9 +674,9 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
      *         - amount1: Actual input quantity used.
      * @return good2change The state change of the output good:
      *         - amount0: Fee quantity deducted.
-     *         - amount1: Actual output quantity paid.
-     * @notice This function calculates the input amount needed to get a specific output amount (inverse swap).
-     * If `_goodid1` == `_goodid2`, it performs a direct transfer with fee deduction.
+     *         - amount1: Gross output quantity from the AMM / direct-pay path before any relayer execution fee.
+     * @notice This function calculates the input amount needed to get a specific gross output amount (inverse swap).
+     * If `_goodid1` == `_goodid2`, it performs a direct transfer path with relayer fee deduction semantics.
      * @custom:security Protected by reentrancy guard.
      * @custom:security Verifies EIP-712 signature if the caller is a relayer.
      * @custom:security Checks max input limit (`_swapQuantity.amount0()`).
@@ -727,7 +733,7 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
             external_info.amount1() != 0
         ) revert TTSwapError(53);
         if (_goodid1 != _goodid2) {
-            // exact-out flow: desired output quantity -> required input value -> required input quantity
+            // Gross-output flow: desired gross output quantity -> required input value -> required input quantity
             good2change = goods[_goodid2].good2Swap(
                 _swapQuantity.amount1(),
                 false
@@ -748,7 +754,7 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
                 good1change.amount1() + good1change.amount0(),
                 data
             );
-            // Transfer output tokens.
+            // Transfer output tokens. In relayer mode, recipient receives gross output minus execution fee.
             if (msg.sender == _trader) {
                 _goodid2.safeTransfer(_recipient, _swapQuantity.amount1());
             } else {
@@ -757,7 +763,8 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
                 feeQuantity = goods[_goodid2]
                     .getGoodState()
                     .getamount1fromamount0(executeFee);
-                if (feeQuantity > good2change.amount1()) revert TTSwapError(50);
+                if (feeQuantity > _swapQuantity.amount1())
+                    revert TTSwapError(50);
                 goods[_goodid2].commission[msg.sender] += feeQuantity;
                 _goodid2.safeTransfer(
                     _recipient,
@@ -779,36 +786,44 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
             );
         } else {
             // Direct payment path (good1 == good2).
-            // No AMM swap, just fee deduction and transfer.
-            _goodid1.transferFrom(
-                _trader,
-                msg.sender,
-                _swapQuantity.amount0(),
-                data
-            );
+            // No AMM swap; the function debits amount0 and, in relayer mode, deducts execution fee from delivery.
+
             good1change = toTTSwapUINT256(
                 goods[_goodid1].currentState.amount1(),
                 goods[_goodid1].investState.amount1()
             );
             if (msg.sender == _trader) {
-                _goodid1.safeTransfer(_recipient, _swapQuantity.amount0());
+                _goodid1.safeTransfer(_recipient, _swapQuantity.amount1());
+                _goodid1.transferFrom(
+                    _trader,
+                    msg.sender,
+                    _swapQuantity.amount1(),
+                    data
+                );
+                good2change = (good2change << 128);
             } else {
                 // Relayer commission calculation.
 
                 feeQuantity = good1change.getamount0fromamount1(executeFee);
-                if (feeQuantity > _swapQuantity.amount0())
+                if (feeQuantity > _swapQuantity.amount1())
                     revert TTSwapError(50);
-                good2change = _swapQuantity.amount0() - feeQuantity;
+                good2change = _swapQuantity.amount1() - feeQuantity;
                 goods[_goodid1].commission[msg.sender] += feeQuantity;
-                if (good2change < _swapQuantity.amount1())
+                if (good2change > _swapQuantity.amount0())
                     revert TTSwapError(55);
                 _goodid1.safeTransfer(_recipient, good2change);
                 good2change = (good2change << 128) + feeQuantity;
+                _goodid1.transferFrom(
+                    _trader,
+                    msg.sender,
+                    _swapQuantity.amount1(),
+                    data
+                );
             }
             emit e_payGood(
                 _goodid1,
                 address(0),
-                good1change.getamount1fromamount0(_swapQuantity.amount0()),
+                good1change.getamount1fromamount0(_swapQuantity.amount1()),
                 _swapQuantity,
                 good2change,
                 _trader,
@@ -1438,5 +1453,10 @@ contract TTSwap_Market is I_TTSwap_Market, IMulticall_v4 {
                     address(this)
                 )
             );
+    }
+
+    /// @inheritdoc I_TTSwap_Market
+    function cancelNonce() external override {
+        nonces[msg.sender] = nonces[msg.sender] + 1;
     }
 }

--- a/src/interfaces/I_TTSwap_Market.sol
+++ b/src/interfaces/I_TTSwap_Market.sol
@@ -248,7 +248,7 @@ interface I_TTSwap_Market {
      * @param _goodid2 The ID of the second good
      * @param _swapQuantity The amount of _goodid1 to swap
      *        - amount0: The quantity of the input good
-     *        - amount1: The limit quantity of the output good
+     *        - amount1: The minimum gross quantity of the output good before any relayer execution fee
      * @param _referral when side is buy, _referral is the referral address when side is sell, _referral is the address to receive the fee
      * @param data Encoded transfer authorization for the input token (Permit/Transfer).
      * @param _trader The trader; `msg.sender` may be a relayer distinct from `_trader` when `signature` is valid.
@@ -269,13 +269,13 @@ interface I_TTSwap_Market {
     ) external payable returns (uint256 good1change, uint256 good2change);
 
     /**
-     * @notice Pays a fixed output amount to recipient using inverse pricing.
+     * @notice Pays a fixed gross output amount using inverse pricing.
      * @param _goodid1 Input good id (payer side).
      * @param _goodid2 Output good id (recipient side).
      * @param _swapQuantity Packed swap params:
      *        - amount0: max input limit.
-     *        - amount1: target output amount.
-     * @param _recipient Address receiving output good.
+     *        - amount1: target gross output amount before any relayer execution fee.
+     * @param _recipient Address receiving output good. In relayer mode, net delivery may be lower because execution fee is deducted from gross output.
      * @param data Additional transfer data for input token (Permit/Transfer).
      * @param _trader The trader; `msg.sender` may be a relayer distinct from `_trader` when `signature` is valid.
      * @param signature EIP-712 signature over the pay payload; **verified** when `msg.sender != _trader`.
@@ -483,6 +483,9 @@ interface I_TTSwap_Market {
         external
         view
         returns (uint256 good1correntstate, uint256 good2correntstate);
+    
+    /// @notice Allows users to proactively increment the nonce to invalidate previously signed offline代付 signatures
+    function cancelNonce() external;
 }
 
 /**

--- a/src/libraries/L_Currency.sol
+++ b/src/libraries/L_Currency.sol
@@ -8,6 +8,7 @@ import {IERC20} from "../interfaces/IERC20.sol";
 import {IDAIPermit} from "../interfaces/IDAIPermit.sol";
 import {L_Transient} from "./L_Transient.sol";
 import {TTSwapError} from "./L_Error.sol";
+import {toUint128} from "./L_TTSwapUINT256.sol";
 
 address constant NATIVE = address(1);
 // // mainnet
@@ -233,7 +234,7 @@ library L_CurrencyLibrary {
         bytes calldata trandata
     ) internal {
         address to = address(this);
-        transferFrom(token, from, to, executor, uint128(amount), trandata);
+        transferFrom(token, from, to, executor, toUint128(amount), trandata);
     }
 
     function transferFromInter(
@@ -350,9 +351,5 @@ library L_CurrencyLibrary {
     function to_uint160(uint256 amount) internal pure returns (uint160) {
         if (amount != uint160(amount)) revert TTSwapError(52);
         return uint160(amount);
-    }
-
-    function to_uint256(address amount) internal pure returns (uint256 a) {
-        return uint256(uint160(amount));
     }
 }

--- a/src/libraries/L_Good.sol
+++ b/src/libraries/L_Good.sol
@@ -420,7 +420,6 @@ library L_Good {
         S_GoodInvestReturn memory investResult_,
         uint128 enpower
     ) internal {
-     
         // Calculate the invest virtual quantity
         // The user receives virtual shares magnified by the power/leverage factor.
 
@@ -489,10 +488,7 @@ library L_Good {
         // Updates a tracking counter in the config (likely for fee/limit calculations), accounting for the leverage.
         _self.goodConfig = add(
             _self.goodConfig,
-            toTTSwapUINT256(
-                0,
-                investResult_.investQuantity - _invest
-            )
+            toTTSwapUINT256(0, investResult_.investQuantity - _invest)
         );
     }
 
@@ -546,8 +542,10 @@ library L_Good {
     {
         // Cache proof fields to avoid repeated SLOADs on the same storage slots
         uint128 proofShares0 = _investProof.shares.amount0();
+        //amount0 :normal good virtual quantity of proof, amount1 :normal good actual quantity of proof
         uint128 proofInvest0 = _investProof.invest.amount0();
         uint128 proofInvest1 = _investProof.invest.amount1();
+        //amount0 :total value of proof,amount1 :total actual value of proof
         uint128 proofState0 = _investProof.state.amount0();
         uint128 proofState1 = _investProof.state.amount1();
 
@@ -567,8 +565,9 @@ library L_Good {
                 _params._goodshares
             ) // Actual quantity to divest (normal good)
         );
-        // Calculate the total value (in terms of the value good) corresponding to the divested portion.
+        // calculate the value from the proof (in terms of the value good) corresponding to the divested portion.
         // Uses proof-time value ratios to preserve value accounting across virtual/actual quantities.
+        // amount0 :total value of proof in terms of the normal good,amount1 :total actual value of proof in terms of the normal good
         disinvestvalue = toTTSwapUINT256(
             toTTSwapUINT256(proofState0, proofInvest0).getamount0fromamount1(
                 normalGoodResult1_.virtualDisinvestQuantity
@@ -578,7 +577,7 @@ library L_Good {
             )
         );
 
-        // Ensure disinvestment conditions are met
+        // ensure the divested value and quantity are within valid ranges.
         // Check limits on how much value can be withdrawn at once to prevent manipulation.
         if (
             disinvestvalue.amount0() >
@@ -606,12 +605,13 @@ library L_Good {
         if (normalGoodResult1_.profit < normalGoodResult1_.actual_fee)
             revert TTSwapError(34);
         // Update main good states
-        // Remove the profit/withdrawn amount from the pool's reserves.
         _self.currentState = sub(
             _self.currentState,
             toTTSwapUINT256(
                 normalGoodResult1_.profit,
-                normalGoodResult1_.profit
+                normalGoodResult1_.virtualDisinvestQuantity +
+                    normalGoodResult1_.profit -
+                    normalGoodResult1_.actualDisinvestQuantity
             )
         );
 
@@ -621,13 +621,15 @@ library L_Good {
             toTTSwapUINT256(normalGoodResult1_.shares, disinvestvalue.amount0())
         );
         // Add the collected fee back into the pool reserves.
-        _self.currentState = add(
-            _self.currentState,
-            toTTSwapUINT256(
-                normalGoodResult1_.actual_fee,
-                normalGoodResult1_.actual_fee
-            )
-        );
+        if (normalGoodResult1_.actual_fee > 0) {
+            _self.currentState = add(
+                _self.currentState,
+                toTTSwapUINT256(
+                    normalGoodResult1_.actual_fee,
+                    normalGoodResult1_.actual_fee
+                )
+            );
+        }
 
         _self.goodConfig = sub(
             _self.goodConfig,
@@ -657,6 +659,7 @@ library L_Good {
             // Calculate disinvestment results for value good
             // proofShares0 already cached above; cache remaining proof fields
             uint128 proofShares1 = _investProof.shares.amount1();
+            //amount0 :value good virtual quantity of proof,amount1 :value good actual quantity of proof
             uint128 proofValueInvest0 = _investProof.valueinvest.amount0();
             uint128 proofValueInvest1 = _investProof.valueinvest.amount1();
             valueGoodResult2_ = S_GoodDisinvestReturn(
@@ -669,13 +672,14 @@ library L_Good {
                 toTTSwapUINT256(proofValueInvest1, proofShares0)
                     .getamount0fromamount1(_params._goodshares)
             );
-            // Ensure value good disinvestment conditions are met
+            // ensure the value good's divested quantity is within valid ranges.
             if (
                 disinvestvalue.amount0() >
                 _valueGoodState.goodConfig.getDisinvestChips(
                     _valueGoodState.investState.amount1()
                 )
             ) revert TTSwapError(28);
+            // Check limits on how much value can be withdrawn at once to prevent manipulation.
             if (
                 valueGoodResult2_.virtualDisinvestQuantity >
                 _valueGoodState.goodConfig.getDisinvestChips(
@@ -683,25 +687,32 @@ library L_Good {
                 )
             ) revert TTSwapError(29);
 
+            // Calculate the current value of the user's shares based on the *current* state of the pool.
             valueGoodResult2_.profit = toTTSwapUINT256(
                 _valueGoodState.currentState.amount0(),
                 _valueGoodState.investState.amount0()
             ).getamount0fromamount1(valueGoodResult2_.shares);
+
+            // Calculate the fee for disinvesting.
             valueGoodResult2_.actual_fee = _valueGoodState
                 .goodConfig
                 .getDisinvestFee(valueGoodResult2_.virtualDisinvestQuantity);
+            // Ensure profit exceeds fees.
             if (valueGoodResult2_.profit < valueGoodResult2_.actual_fee)
                 revert TTSwapError(34);
 
             // Update value good states
+            // Reduce the global investment state (shares and value) by the amount being withdrawn.
             _valueGoodState.currentState = sub(
                 _valueGoodState.currentState,
                 toTTSwapUINT256(
-                    valueGoodResult2_.actualDisinvestQuantity,
-                    valueGoodResult2_.virtualDisinvestQuantity
+                    valueGoodResult2_.profit,
+                    valueGoodResult2_.virtualDisinvestQuantity +
+                        valueGoodResult2_.profit -
+                        valueGoodResult2_.actualDisinvestQuantity
                 )
             );
-
+            // Reduce the global investment state (shares and value) by the amount being withdrawn.
             _valueGoodState.investState = sub(
                 _valueGoodState.investState,
                 toTTSwapUINT256(
@@ -709,24 +720,27 @@ library L_Good {
                     disinvestvalue.amount1()
                 )
             );
-
-            _valueGoodState.currentState = add(
-                _valueGoodState.currentState,
-                toTTSwapUINT256(
-                    valueGoodResult2_.actual_fee,
-                    valueGoodResult2_.actual_fee
-                )
-            );
+            // Add the collected fee back into the pool reserves.
+            if (valueGoodResult2_.actual_fee > 0) {
+                _valueGoodState.currentState = add(
+                    _valueGoodState.currentState,
+                    toTTSwapUINT256(
+                        valueGoodResult2_.actual_fee,
+                        valueGoodResult2_.actual_fee
+                    )
+                );
+            }
+            // Remove the virtual quantity of goods redeemed from the good's configuration.
             _valueGoodState.goodConfig = sub(
                 _valueGoodState.goodConfig,
                 valueGoodResult2_.virtualDisinvestQuantity -
                     valueGoodResult2_.actualDisinvestQuantity
             );
-
+            // Net profit = Gross withdrawn value - Initial invested actual quantity.
             valueGoodResult2_.profit =
                 valueGoodResult2_.profit -
                 valueGoodResult2_.actualDisinvestQuantity;
-
+            // Allocate fees
             allocateFee(
                 _valueGoodState,
                 valueGoodResult2_.profit,

--- a/test/PowerWithFee.t.sol
+++ b/test/PowerWithFee.t.sol
@@ -150,7 +150,7 @@ contract PowerWithFee is BaseSetup {
         );
         assertEq(
             good_.currentState.amount1(),
-            289988499674,
+            269989499725,
             "after disinvest nativeeth good:metagood currentState amount1 error"
         );
         assertEq(

--- a/test/PowerWithoutFee.t.sol
+++ b/test/PowerWithoutFee.t.sol
@@ -135,7 +135,7 @@ contract PowerWithoutFee is BaseSetup {
         );
         assertEq(
             good_.currentState.amount1(),
-            290000000000,
+            270000000000,
             "after disinvest nativeeth good:metagood currentState amount1 error"
         );
         assertEq(


### PR DESCRIPTION
Refined the payGood specification and supporting docs to use a single, explicit model where amount1 represents gross output and relayer execution fees are deducted from output in relayed settlement. Updated contract/interface annotations and whitepaper text to match this behavior, then revised audit artifacts (EN/ZH) so findings reflect the new semantic baseline, focusing on same-token branch consistency and protocol fee custody risk.